### PR TITLE
Fix click on sidebar link

### DIFF
--- a/js/fresh.js
+++ b/js/fresh.js
@@ -33,7 +33,7 @@ $(document).ready(function () {
 
     //Sidebar menu
     if ($('.sidebar').length) {
-        $(".sidebar-menu > li.have-children a").on("click", function (i) {
+        $(".sidebar-menu > li.have-children > a").on("click", function (i) {
             i.preventDefault();
             if (!$(this).parent().hasClass("active")) {
                 $(".sidebar-menu li ul").slideUp();


### PR DESCRIPTION
A click on link in the sidebar just collapsed the menu item but doesn't go to the link...
This will fix it.

See also https://github.com/StefMa/hugo-fresh/pull/42/files and the issue https://github.com/StefMa/hugo-fresh/issues/17